### PR TITLE
make ENV.hoodie.client config optional

### DIFF
--- a/addon/services/hoodie.js
+++ b/addon/services/hoodie.js
@@ -9,15 +9,16 @@ const {
 export default Service.extend({
   init() {
     this._super(...arguments);
-    let config = Ember.getOwner(this).application.resolveRegistration('config:environment').hoodie.client
-    let hoodie = new Hoodie(config);
+    const appConfig = Ember.getOwner(this).application.resolveRegistration('config:environment')
+    const hoodieConfig = appConfig.hoodie ? appConfig.hoodie.client : {}
+    const hoodie = new Hoodie(hoodieConfig);
     set(this, 'hoodie', hoodie);
     // for debug only
     window.hoodie = hoodie;
   },
 
   unknownProperty(keyName) {
-    let hoodie = get(this, 'hoodie');
+    const hoodie = get(this, 'hoodie');
     if (keyName in hoodie) {
       return hoodie[keyName];
     } else {


### PR DESCRIPTION
closes #22 

I’ve tested this fix locally with our app which broke due to #20. I’ll merge it in right away to avoid other apps from breaking with a feature release, but please review anyway, and if we find something, I’ll start a follow up PR.

Sorry for that
