### PR TITLE
fix: make it possible to use Hoodie Client only

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function hoodieMiddleware(config) {
   var appConfig = this.project.config(config.options.environment);
   /* jshint +W040 */
 
-  if (!appConfig.hoodie) {
+  if (!appConfig.hoodie.server) {
     return;
   }
 


### PR DESCRIPTION
If `ENV.hoodie` contains only configuration for the client, `hoodieMiddleware()` still tries to start Hoodie Server, which results in an error. This PR changes the check to be specific to the server configuration only.